### PR TITLE
fix(industries): put information in tabs, to declutter the overview

### DIFF
--- a/src/lib/components/cargo/index.svelte
+++ b/src/lib/components/cargo/index.svelte
@@ -5,6 +5,7 @@
 
     import { Button } from "carbon-components-svelte";
     import { Modal } from "carbon-components-svelte";
+    import { Tabs, Tab, TabContent } from "carbon-components-svelte";
 
     import ColorPicker from "$lib/components/ui/color-picker.svelte";
     import NumberInput from "$lib/components/ui/number-input.svelte";
@@ -141,152 +142,169 @@
 </script>
 
 <div class="listing">
-    <div class="flex">
-        <Switch
-            labelText="Availability"
-            labelOff="Hidden"
-            labelOn="Available"
-            bind:value={cargo.available}
-            on:change={OnChange}
-        />
-        <Button
-            kind="danger-tertiary"
-            iconDescription="Delete cargo"
-            icon={TrashCan}
-            size="small"
-            tooltipPosition="bottom"
-            tooltipAlignment="end"
-            on:click={() => (deleteCargoOpen = true)}
-        />
-    </div>
+    <Tabs class="subnav">
+        <Tab label="Properties" />
+        <Tab label="Graphics" />
 
-    <br />
+        <svelte:fragment slot="content">
+            <TabContent>
+                <div class="flex">
+                    <Switch
+                        labelText="Availability"
+                        labelOff="Hidden"
+                        labelOn="Available"
+                        bind:value={cargo.available}
+                        on:change={OnChange}
+                    />
+                    <Button
+                        kind="danger-tertiary"
+                        iconDescription="Delete cargo"
+                        icon={TrashCan}
+                        size="small"
+                        tooltipPosition="bottom"
+                        tooltipAlignment="end"
+                        on:click={() => (deleteCargoOpen = true)}
+                    />
+                </div>
 
-    <TextInput
-        labelText="Label"
-        placeholder="Label of cargo"
-        validate={ValidateLabel}
-        bind:value={cargo.label}
-        on:change={OnChange}
-    />
-    <TextInput
-        labelText="Abbreviation"
-        placeholder="Abbreviation of cargo"
-        validate={ValidateAbbreviation}
-        bind:value={cargo.abbreviation}
-        on:change={OnChange}
-    />
-    <TextInput
-        labelText="Name"
-        placeholder="Name of cargo"
-        validate={ValidateName}
-        bind:value={cargo.name}
-        on:change={OnChange}
-    />
-    <Select options={units} labelText="Unit" bind:value={cargo.unitName} on:change={OnChangeUnit} />
-    <ColorPicker labelText="Colour" bind:value={cargo.colour} on:change={OnChange} />
+                <br />
 
-    <br />
+                <TextInput
+                    labelText="Label"
+                    placeholder="Label of cargo"
+                    validate={ValidateLabel}
+                    bind:value={cargo.label}
+                    on:change={OnChange}
+                />
+                <TextInput
+                    labelText="Abbreviation"
+                    placeholder="Abbreviation of cargo"
+                    validate={ValidateAbbreviation}
+                    bind:value={cargo.abbreviation}
+                    on:change={OnChange}
+                />
+                <TextInput
+                    labelText="Name"
+                    placeholder="Name of cargo"
+                    validate={ValidateName}
+                    bind:value={cargo.name}
+                    on:change={OnChange}
+                />
+                <Select options={units} labelText="Unit" bind:value={cargo.unitName} on:change={OnChangeUnit} />
+                <ColorPicker labelText="Colour" bind:value={cargo.colour} on:change={OnChange} />
 
-    <Select options={classes} labelText="Cargo class" bind:value={cargoClass} on:change={OnChangeCargoClass} />
-    <SegmentedButton
-        options={currentClassesOptional}
-        labelText="Cargo class options"
-        bind:selection={cargoClassOptional}
-        on:change={OnChangeCargoClassOptional}
-    />
-    <Slider
-        min={0}
-        max={2000}
-        step={62.5}
-        unit="kg"
-        disabled={cargo.unitName === "Tonnes"}
-        bind:value={weight}
-        on:change={OnChangeWeight}
-    >
-        <svelte:fragment slot="labelText">
-            Weight per
-            {#if cargo.unitName === "Tonnes"}
-                ton
-            {:else if cargo.unitName === "Passengers"}
-                passenger
-            {:else if cargo.unitName === "Bags"}
-                bag
-            {:else if cargo.unitName === "Items"}
-                item
-            {:else if cargo.unitName === "Crates"}
-                crate
-            {:else if cargo.unitName === "Litres"}
-                1,000 litres
-            {/if}
+                <br />
+
+                <Select
+                    options={classes}
+                    labelText="Cargo class"
+                    bind:value={cargoClass}
+                    on:change={OnChangeCargoClass}
+                />
+                <SegmentedButton
+                    options={currentClassesOptional}
+                    labelText="Cargo class options"
+                    bind:selection={cargoClassOptional}
+                    on:change={OnChangeCargoClassOptional}
+                />
+                <Slider
+                    min={0}
+                    max={2000}
+                    step={62.5}
+                    unit="kg"
+                    disabled={cargo.unitName === "Tonnes"}
+                    bind:value={weight}
+                    on:change={OnChangeWeight}
+                >
+                    <svelte:fragment slot="labelText">
+                        Weight per
+                        {#if cargo.unitName === "Tonnes"}
+                            ton
+                        {:else if cargo.unitName === "Passengers"}
+                            passenger
+                        {:else if cargo.unitName === "Bags"}
+                            bag
+                        {:else if cargo.unitName === "Items"}
+                            item
+                        {:else if cargo.unitName === "Crates"}
+                            crate
+                        {:else if cargo.unitName === "Litres"}
+                            1,000 litres
+                        {/if}
+                    </svelte:fragment>
+                </Slider>
+
+                <br />
+
+                <NumberInput
+                    labelText="Price in pounds"
+                    placeholder="Price of cargo"
+                    min={1}
+                    bind:value={price}
+                    on:change={OnChangePrice}
+                >
+                    <svelte:fragment slot="tooltip">
+                        Price per
+                        {#if cargo.unitName === "Tonnes"}
+                            10 tonnes
+                        {:else if cargo.unitName === "Passengers"}
+                            10 passengers
+                        {:else if cargo.unitName === "Bags"}
+                            10 bags
+                        {:else if cargo.unitName === "Items"}
+                            10 item
+                        {:else if cargo.unitName === "Crates"}
+                            10 crate
+                        {:else if cargo.unitName === "Litres"}
+                            10,000 litres
+                        {/if}
+                        across 20 tiles in pounds
+                    </svelte:fragment>
+                </NumberInput>
+                <Slider
+                    labelText="Penalty (lowerbound)"
+                    min={0}
+                    max={637.5}
+                    step={2.5}
+                    unit="days"
+                    bind:value={penaltyLowerBound}
+                    on:change={OnChangePenalty}
+                >
+                    <svelte:fragment slot="tooltip">
+                        The first mark indicates after how many days in transit the price of the cargo starts to drop
+                        with 0.16% per extra day in transit.<br />
+                        The second mark indicates after how many days this becomes 0.31% per extra day in transit.<br />
+                        The price can never drop below 12% of the original price.
+                    </svelte:fragment>
+                </Slider>
+                <Slider
+                    labelText="Penalty (upperbound)"
+                    min={0}
+                    max={637.5}
+                    step={2.5}
+                    unit="days"
+                    bind:value={penaltyUpperBound}
+                    on:change={OnChangePenalty}
+                />
+            </TabContent>
+            <TabContent>
+                <div class="bx--form-item bx--text-input-wrapper bx--text-input-wrapper--inline">
+                    <div class="bx--text-input__label-helper-wrapper">
+                        <span class="bx--label--inline--sm bx--label bx--label--inline">
+                            <slot name="labelText">Sprite</slot>
+                        </span>
+                    </div>
+                    <SpriteEditor
+                        bind:base64Data={images[cargo.sprite.filename]}
+                        colour={spriteColour}
+                        on:change={OnChange}
+                    />
+
+                    <Palette bind:selected={spriteColour} />
+                </div>
+            </TabContent>
         </svelte:fragment>
-    </Slider>
-
-    <br />
-
-    <NumberInput
-        labelText="Price in pounds"
-        placeholder="Price of cargo"
-        min={1}
-        bind:value={price}
-        on:change={OnChangePrice}
-    >
-        <svelte:fragment slot="tooltip">
-            Price per
-            {#if cargo.unitName === "Tonnes"}
-                10 tonnes
-            {:else if cargo.unitName === "Passengers"}
-                10 passengers
-            {:else if cargo.unitName === "Bags"}
-                10 bags
-            {:else if cargo.unitName === "Items"}
-                10 item
-            {:else if cargo.unitName === "Crates"}
-                10 crate
-            {:else if cargo.unitName === "Litres"}
-                10,000 litres
-            {/if}
-            across 20 tiles in pounds
-        </svelte:fragment>
-    </NumberInput>
-    <Slider
-        labelText="Penalty (lowerbound)"
-        min={0}
-        max={637.5}
-        step={2.5}
-        unit="days"
-        bind:value={penaltyLowerBound}
-        on:change={OnChangePenalty}
-    >
-        <svelte:fragment slot="tooltip">
-            The first mark indicates after how many days in transit the price of the cargo starts to drop with 0.16% per
-            extra day in transit.<br />
-            The second mark indicates after how many days this becomes 0.31% per extra day in transit.<br />
-            The price can never drop below 12% of the original price.
-        </svelte:fragment>
-    </Slider>
-    <Slider
-        labelText="Penalty (upperbound)"
-        min={0}
-        max={637.5}
-        step={2.5}
-        unit="days"
-        bind:value={penaltyUpperBound}
-        on:change={OnChangePenalty}
-    />
-
-    <br />
-
-    <div class="bx--form-item bx--text-input-wrapper bx--text-input-wrapper--inline">
-        <div class="bx--text-input__label-helper-wrapper">
-            <span class="bx--label--inline--sm bx--label bx--label--inline">
-                <slot name="labelText">Sprite</slot>
-            </span>
-        </div>
-        <SpriteEditor bind:base64Data={images[cargo.sprite.filename]} colour={spriteColour} on:change={OnChange} />
-
-        <Palette bind:selected={spriteColour} />
-    </div>
+    </Tabs>
 
     <Modal
         bind:open={deleteCargoOpen}
@@ -308,5 +326,11 @@
 
     .flex {
         display: flex;
+    }
+
+    .listing :global(.subnav) {
+        display: flex;
+        width: 100%;
+        justify-content: center;
     }
 </style>

--- a/src/lib/components/industry/index.svelte
+++ b/src/lib/components/industry/index.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
     import { createEventDispatcher } from "svelte";
 
+    import Add from "carbon-icons-svelte/lib/Add.svelte";
     import TrashCan from "carbon-icons-svelte/lib/TrashCan.svelte";
 
     import { Button } from "carbon-components-svelte";
     import { Modal } from "carbon-components-svelte";
     import { Pagination } from "carbon-components-svelte";
+    import { Tabs, Tab, TabContent } from "carbon-components-svelte";
     import { TextArea } from "carbon-components-svelte";
 
     import Layout from "$lib/components/industry/layout.svelte";
@@ -29,6 +31,7 @@
     let cargoesItems = [];
     let selectedLayout = 1;
     let deleteIndustryOpen = false;
+    let deleteLayoutOpen = false;
 
     function DeleteIndustry() {
         dispatch("delete", industry.id);
@@ -45,6 +48,8 @@
     }
 
     function DeleteLayout() {
+        deleteLayoutOpen = false;
+
         industry.layout.splice(selectedLayout - 1, 1);
 
         if (industry.layout.length === 0) {
@@ -100,137 +105,173 @@
 </script>
 
 <div class="listing">
-    <div class="flex">
-        <Switch
-            labelText="Availability"
-            labelOff="Hidden"
-            labelOn="Available"
-            bind:value={industry.available}
-            on:change={OnChange}
-        />
-        <Button
-            kind="danger-tertiary"
-            iconDescription="Delete industry"
-            icon={TrashCan}
-            size="small"
-            tooltipPosition="bottom"
-            tooltipAlignment="end"
-            on:click={() => (deleteIndustryOpen = true)}
-        />
-    </div>
+    <Tabs class="subnav">
+        <Tab label="Properties" />
+        <Tab label="Graphics" />
+        <Tab label="Callbacks" />
 
-    <br />
+        <svelte:fragment slot="content">
+            <TabContent>
+                <div class="flex">
+                    <Switch
+                        labelText="Availability"
+                        labelOff="Hidden"
+                        labelOn="Available"
+                        bind:value={industry.available}
+                        on:change={OnChange}
+                    />
+                    <Button
+                        kind="danger-tertiary"
+                        iconDescription="Delete industry"
+                        icon={TrashCan}
+                        size="small"
+                        tooltipPosition="bottom"
+                        tooltipAlignment="end"
+                        on:click={() => (deleteIndustryOpen = true)}
+                    />
+                </div>
 
-    <TextInput
-        labelText="Name"
-        placeholder="Name of industry"
-        validate={ValidateName}
-        bind:value={industry.name}
-        on:change={OnChange}
-    />
-    <Select options={types} labelText="Type" bind:value={industry.type} on:change={OnChange} />
-    <Select options={placement} labelText="Placement" bind:value={industry.placement} on:change={OnChange} />
+                <br />
 
-    <br />
+                <TextInput
+                    labelText="Name"
+                    placeholder="Name of industry"
+                    validate={ValidateName}
+                    bind:value={industry.name}
+                    on:change={OnChange}
+                />
+                <Select options={types} labelText="Type" bind:value={industry.type} on:change={OnChange} />
+                <Select
+                    options={placement}
+                    labelText="Placement"
+                    bind:value={industry.placement}
+                    on:change={OnChange}
+                />
 
-    <Slider
-        labelText="Probability (Map Generation)"
-        min={0}
-        max={30}
-        step={1}
-        bind:value={industry.probabilityMapGen}
-        on:change={OnChange}
-    >
-        <svelte:fragment slot="tooltip">
-            This is a relative value to other industries.<br />
-            In other words, if industry A has this on 1, and industry B on 2, industry B has twice the chance of spawning
-            as industry A.
+                <br />
+
+                <Slider
+                    labelText="Probability (Map Generation)"
+                    min={0}
+                    max={30}
+                    step={1}
+                    bind:value={industry.probabilityMapGen}
+                    on:change={OnChange}
+                >
+                    <svelte:fragment slot="tooltip">
+                        This is a relative value to other industries.<br />
+                        In other words, if industry A has this on 1, and industry B on 2, industry B has twice the chance
+                        of spawning as industry A.
+                    </svelte:fragment>
+                </Slider>
+                <Slider
+                    labelText="Probability (In Game)"
+                    min={0}
+                    max={30}
+                    step={1}
+                    bind:value={industry.probabilityInGame}
+                    on:change={OnChange}
+                >
+                    <svelte:fragment slot="tooltip">
+                        This is a relative value to other industries.<br />
+                        In other words, if industry A has this on 1, and industry B on 2, industry B has twice the chance
+                        of spawning as industry A.
+                    </svelte:fragment>
+                </Slider>
+                <Slider
+                    labelText="Prospect Success Chance"
+                    min={0}
+                    max={100}
+                    step={1}
+                    unit="%"
+                    bind:value={industry.prospectChance}
+                    disabled={industry.type !== "primary"}
+                    on:change={OnChange}
+                />
+                <Slider
+                    labelText="Fund Cost Multiplier"
+                    min={0}
+                    max={255}
+                    step={1}
+                    bind:value={industry.fundCostMultiplier}
+                    on:change={OnChange}
+                />
+
+                <br />
+
+                <MultiSelect
+                    labelText="Cargo acceptance"
+                    bind:selected={industry.cargoAcceptance}
+                    items={cargoesItems}
+                    on:change={OnChange}
+                />
+                <MultiSelect
+                    labelText="Cargo production"
+                    bind:selected={industry.cargoProduction}
+                    items={cargoesItems}
+                    on:change={OnChange}
+                />
+            </TabContent>
+            <TabContent>
+                <div class="flex navigation">
+                    <Pagination
+                        bind:page={selectedLayout}
+                        totalItems={industry.layout.length}
+                        pageSize={1}
+                        pageSizeInputDisabled
+                        forwardText="Next layout"
+                        backwardText="Previous layout"
+                        itemRangeText={(min) => `Layout #${min}`}
+                        pageRangeText={(_, total) => `of ${total} layouts`}
+                    />
+                    <Button
+                        kind="ghost"
+                        iconDescription="New layout"
+                        icon={Add}
+                        size="small"
+                        tooltipPosition="bottom"
+                        tooltipAlignment="end"
+                        class="bx--pagination__button buttons"
+                        on:click={() => CreateLayout()}
+                    />
+
+                    <Button
+                        kind="danger-ghost"
+                        iconDescription="Delete layout"
+                        icon={TrashCan}
+                        size="small"
+                        tooltipPosition="bottom"
+                        tooltipAlignment="end"
+                        class="bx--pagination__button buttons delete-layout"
+                        on:click={() => (deleteLayoutOpen = true)}
+                    />
+                </div>
+                <Layout
+                    id={industry.name}
+                    bind:layout={industry.layout[selectedLayout - 1]}
+                    bind:tiles={industry.tiles}
+                    {images}
+                    on:delete={DeleteLayout}
+                    on:create={CreateLayout}
+                />
+            </TabContent>
+            <TabContent>
+                <TextArea
+                    placeholder="Define your custom callbacks here"
+                    bind:value={industry.callbacks}
+                    rows={35}
+                    on:change={OnChange}
+                />
+                <p class="bx--form__helper-text">
+                    Callbacks scripting is done in a language specifically designed for TrueGRF. See <a
+                        target="_new"
+                        href="https://github.com/TrueGRF/TrueGRF-rs/blob/main/src/grf/actions/action2_rpn/README.md"
+                        >here</a
+                    > for documentation on the language.
+                </p>
+            </TabContent>
         </svelte:fragment>
-    </Slider>
-    <Slider
-        labelText="Probability (In Game)"
-        min={0}
-        max={30}
-        step={1}
-        bind:value={industry.probabilityInGame}
-        on:change={OnChange}
-    >
-        <svelte:fragment slot="tooltip">
-            This is a relative value to other industries.<br />
-            In other words, if industry A has this on 1, and industry B on 2, industry B has twice the chance of spawning
-            as industry A.
-        </svelte:fragment>
-    </Slider>
-    <Slider
-        labelText="Prospect Success Chance"
-        min={0}
-        max={100}
-        step={1}
-        unit="%"
-        bind:value={industry.prospectChance}
-        disabled={industry.type !== "primary"}
-        on:change={OnChange}
-    />
-    <Slider
-        labelText="Fund Cost Multiplier"
-        min={0}
-        max={255}
-        step={1}
-        bind:value={industry.fundCostMultiplier}
-        on:change={OnChange}
-    />
-
-    <br />
-
-    <MultiSelect
-        labelText="Cargo acceptance"
-        bind:selected={industry.cargoAcceptance}
-        items={cargoesItems}
-        on:change={OnChange}
-    />
-    <MultiSelect
-        labelText="Cargo production"
-        bind:selected={industry.cargoProduction}
-        items={cargoesItems}
-        on:change={OnChange}
-    />
-
-    <br />
-
-    <TextArea
-        labelText="Callbacks"
-        placeholder="Define your custom callbacks here"
-        bind:value={industry.callbacks}
-        rows={10}
-        on:change={OnChange}
-    />
-    <p class="bx--form__helper-text">
-        Callbacks scripting is done in a language specifically designed for TrueGRF. See <a
-            target="_new"
-            href="https://github.com/TrueGRF/TrueGRF-rs/blob/main/src/grf/actions/action2_rpn/README.md">here</a
-        > for documentation on the language.
-    </p>
-
-    <br />
-
-    <Pagination
-        bind:page={selectedLayout}
-        totalItems={industry.layout.length}
-        pageSize={1}
-        pageSizeInputDisabled
-        forwardText="Next Layout"
-        backwardText="Previous Layout"
-        itemRangeText={(min) => `Layout #${min}`}
-        pageRangeText={(_, total) => `of ${total} layouts`}
-    />
-    <Layout
-        id={industry.name}
-        bind:layout={industry.layout[selectedLayout - 1]}
-        bind:tiles={industry.tiles}
-        {images}
-        on:delete={DeleteLayout}
-        on:create={CreateLayout}
-    />
+    </Tabs>
 
     <Modal
         bind:open={deleteIndustryOpen}
@@ -243,6 +284,18 @@
     >
         Are you sure you want to delete '{industry.name}'?
     </Modal>
+
+    <Modal
+        bind:open={deleteLayoutOpen}
+        modalHeading="Delete layout?"
+        primaryButtonText="Delete"
+        secondaryButtonText="Cancel"
+        on:click:button--secondary={() => (deleteLayoutOpen = false)}
+        on:click:button--primary={() => DeleteLayout()}
+        danger
+    >
+        Are you sure you want to delete this layout?
+    </Modal>
 </div>
 
 <style>
@@ -252,5 +305,27 @@
 
     .flex {
         display: flex;
+    }
+
+    .listing :global(.subnav) {
+        display: flex;
+        width: 100%;
+        justify-content: center;
+    }
+    .navigation {
+        margin-bottom: 12px;
+    }
+
+    .navigation :global(.buttons) {
+        background-color: var(--cds-ui-01, #f4f4f4);
+        border-top: 1px solid var(--cds-ui-03, #e0e0e0);
+        height: 41px;
+        padding: 0;
+    }
+    .navigation :global(.buttons:hover) {
+        background-color: var(--cds-hover-ui, #e5e5e5);
+    }
+    .navigation :global(.delete-layout > svg) {
+        margin-left: 0.25rem;
     }
 </style>

--- a/src/lib/components/industry/layout.svelte
+++ b/src/lib/components/industry/layout.svelte
@@ -1,12 +1,6 @@
 <script lang="ts">
     import { createEventDispatcher } from "svelte";
 
-    import Add from "carbon-icons-svelte/lib/Add.svelte";
-    import TrashCan from "carbon-icons-svelte/lib/TrashCan.svelte";
-
-    import { Button } from "carbon-components-svelte";
-    import { Modal } from "carbon-components-svelte";
-
     import Grid from "$lib/components/industry/grid.svelte";
     import Slider from "$lib/components/ui/slider.svelte";
     import Tiles from "$lib/components/industry/tiles.svelte";
@@ -25,16 +19,6 @@
     let tileSelected;
     let sizeX;
     let sizeY;
-    let deleteLayoutOpen = false;
-
-    function DeleteLayout() {
-        dispatch("delete");
-        deleteLayoutOpen = false;
-    }
-
-    function CreateLayout() {
-        dispatch("create");
-    }
 
     function UpdateLayout() {
         sizeX = layout[0].length;
@@ -95,36 +79,12 @@
 </script>
 
 <div class="layout">
-    <div class="flex">
-        <div>
-            <Slider labelText="⤢ size" min={1} max={8} step={1} bind:value={sizeX} on:change={OnSizeChange} />
-            <Slider labelText="⤡ size" min={1} max={8} step={1} bind:value={sizeY} on:change={OnSizeChange} />
-        </div>
-
-        <div>
-            <Button
-                kind="tertiary"
-                iconDescription="New layout"
-                icon={Add}
-                size="small"
-                tooltipPosition="bottom"
-                tooltipAlignment="end"
-                on:click={() => CreateLayout()}
-            />
-
-            <Button
-                kind="danger-tertiary"
-                iconDescription="Delete layout"
-                icon={TrashCan}
-                size="small"
-                tooltipPosition="bottom"
-                tooltipAlignment="end"
-                on:click={() => (deleteLayoutOpen = true)}
-            />
-        </div>
+    <div>
+        <Slider labelText="⤢ size" min={1} max={8} step={1} bind:value={sizeX} on:change={OnSizeChange} />
+        <Slider labelText="⤡ size" min={1} max={8} step={1} bind:value={sizeY} on:change={OnSizeChange} />
     </div>
 
-    <div class="column">
+    <div class="flex">
         <div class="grid">
             <Grid {images} {layout} {tiles} bind:selected={gridSelected} on:select={OnGridSelect} />
         </div>
@@ -132,37 +92,16 @@
             <Tiles {images} {tiles} {id} selected={tileSelected} on:select={OnTileSelect} on:change={OnTileChange} />
         </div>
     </div>
-
-    <Modal
-        bind:open={deleteLayoutOpen}
-        modalHeading="Delete layout?"
-        primaryButtonText="Delete"
-        secondaryButtonText="Cancel"
-        on:click:button--secondary={() => (deleteLayoutOpen = false)}
-        on:click:button--primary={() => DeleteLayout()}
-        danger
-    >
-        Are you sure you want to delete this layout?
-    </Modal>
 </div>
 
 <style>
-    .column {
-        display: flex;
-        justify-content: space-between;
-    }
-
     .flex {
         display: flex;
         justify-content: space-between;
     }
 
-    .flex :global(.bx--btn) {
-        height: 2rem;
-        margin-top: 1rem;
-    }
-
     .tiles {
+        margin-top: 12px;
         width: calc(64px * 5);
     }
 </style>

--- a/src/lib/components/ui/multi-select.svelte
+++ b/src/lib/components/ui/multi-select.svelte
@@ -92,7 +92,7 @@
 
     .tags {
         margin-right: 280px;
-        width: 494px;
+        width: 454px;
     }
 
     .tags .none {

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -294,7 +294,7 @@
             {:else if !loadedProject}
                 <div class="content center">Processing data ...</div>
             {:else}
-                <Tabs type="container" class="topnav" on:change={TabSelected}>
+                <Tabs class="topnav" on:change={TabSelected}>
                     <Tab label="Editing" />
                     <Tab label="Testing" />
                     <Tab label="Project">


### PR DESCRIPTION
There was a lot of information for industries presented, which made
it a bit hard to actually get an overview of what is going on. By
adding tabs, it becomes a lot more clear what is happening. It also
makes it a lot easier to work on callbacks or graphics.