### PR TITLE
fix(townnames): crash as new townnames did not have any parts in the mainset

### DIFF
--- a/src/lib/components/townname/newTownname.ts
+++ b/src/lib/components/townname/newTownname.ts
@@ -2,7 +2,7 @@ export const newTownname = {
     available: false,
     id: undefined, // Filled in after creation.
     name: "New Townname",
-    mainset: [],
+    mainset: [{ names: [] }],
     source: "",
     subsets: [],
 };


### PR DESCRIPTION
There should always be at least a single part in any set.

Fixes #75.

For sets that are broken, simply adding a part in the mainset resolves the issue.